### PR TITLE
Add EUR/USD currency toggle to Plans page with EUR as default

### DIFF
--- a/_site/plans/index.html
+++ b/_site/plans/index.html
@@ -100,6 +100,13 @@
       <label for="ui-component-toggle__yearly" class="ui-component-toggle--label">Annual -10%</label>
     </div>
     <p class="ui-text-intro"><small>Choose monthly or annual billing to see the discount.</small></p>
+    <input type="radio" id="ui-component-toggle__eur" name="currency" checked>
+    <input type="radio" id="ui-component-toggle__usd" name="currency">
+    <div class="ui-component-toggle ui-layout-flex">
+      <label for="ui-component-toggle__eur" class="ui-component-toggle--label">EUR (€)</label>
+      <label for="ui-component-toggle__usd" class="ui-component-toggle--label">USD ($)</label>
+    </div>
+    <p class="ui-text-intro"><small>Select your billing currency.</small></p>
     <div class="ui-section-pricing__layout ui-layout-grid ui-layout-grid-3">
       <div class="ui-component-card ui-component-card--pricing">
         <h2>Free</h2>

--- a/_site/style.css
+++ b/_site/style.css
@@ -323,6 +323,10 @@ svg {
 
 input[name="toggle"] { display: none; }
 
+input[type="radio"][id^="ui-component-toggle__"] {
+  display: none;
+}
+
 .ui-component-toggle {
   background-color: var(--ui-color-background-tertiary);
   border-radius: var(--ui-radius-button);
@@ -358,7 +362,11 @@ input[name="toggle"] { display: none; }
 .page--plans #ui-component-toggle__monthly:checked ~
 div label[for=ui-component-toggle__monthly],
 .page--plans #ui-component-toggle__yearly:checked ~
-div label[for=ui-component-toggle__yearly] {
+div label[for=ui-component-toggle__yearly],
+.page--plans #ui-component-toggle__eur:checked ~
+div label[for=ui-component-toggle__eur],
+.page--plans #ui-component-toggle__usd:checked ~
+div label[for=ui-component-toggle__usd] {
   background-color: #4c97d9;
   color: #fff;
 }
@@ -815,29 +823,71 @@ div label[for=ui-component-toggle__yearly] {
 
 /* AMOUNT */
 
-.ui-component-card--pricing-amount-0::before { content: "$0"; }
+/* Default: Monthly EUR */
+.ui-component-card--pricing-amount-0::before { content: "€0"; }
 
+/* Yearly EUR */
 #ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-0::before { content: "€0"; }
+
+/* Monthly EUR */
+.ui-component-card--pricing-amount-1::before { content: "€30"; }
+
+/* Yearly EUR */
+#ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-1::before { content: "€27"; }
+
+/* Monthly EUR */
+.ui-component-card--pricing-amount-2::before { content: "€60"; }
+
+/* Yearly EUR */
+#ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-2::before { content: "€54"; }
+
+/* Monthly EUR */
+.ui-component-card--pricing-amount-3::before { content: "€90"; }
+
+/* Yearly EUR */
+#ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-3::before { content: "€81"; }
+
+/* Monthly EUR */
+.ui-component-card--pricing-amount-4::before { content: "€150"; }
+
+/* Yearly EUR */
+#ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-4::before { content: "€135"; }
+
+/* Monthly USD */
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-0::before { content: "$0"; }
 
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-1::before { content: "$30"; }
 
-#ui-component-toggle__yearly:checked ~ div
-.ui-component-card--pricing-amount-1::before { content: "$27"; }
-
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-2::before { content: "$60"; }
 
-#ui-component-toggle__yearly:checked ~ div
-.ui-component-card--pricing-amount-2::before { content: "$54"; }
-
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-3::before { content: "$90"; }
 
-#ui-component-toggle__yearly:checked ~ div
-.ui-component-card--pricing-amount-3::before { content: "$81"; }
-
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-4::before { content: "$150"; }
 
-#ui-component-toggle__yearly:checked ~ div
+/* Yearly USD */
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
+.ui-component-card--pricing-amount-0::before { content: "$0"; }
+
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
+.ui-component-card--pricing-amount-1::before { content: "$27"; }
+
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
+.ui-component-card--pricing-amount-2::before { content: "$54"; }
+
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
+.ui-component-card--pricing-amount-3::before { content: "$81"; }
+
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-4::before { content: "$135"; }
 
 /* LIST */

--- a/plans/index.liquid
+++ b/plans/index.liquid
@@ -16,6 +16,13 @@ description: Explore plans and pricing for WebPerformance Report. Automated repo
       <label for="ui-component-toggle__yearly" class="ui-component-toggle--label">Annual -10%</label>
     </div>
     <p class="ui-text-intro"><small>Choose monthly or annual billing to see the discount.</small></p>
+    <input type="radio" id="ui-component-toggle__eur" name="currency" checked>
+    <input type="radio" id="ui-component-toggle__usd" name="currency">
+    <div class="ui-component-toggle ui-layout-flex">
+      <label for="ui-component-toggle__eur" class="ui-component-toggle--label">EUR (€)</label>
+      <label for="ui-component-toggle__usd" class="ui-component-toggle--label">USD ($)</label>
+    </div>
+    <p class="ui-text-intro"><small>Select your billing currency.</small></p>
     <div class="ui-section-pricing__layout ui-layout-grid ui-layout-grid-3">
       <div class="ui-component-card ui-component-card--pricing">
         <h2>Free</h2>

--- a/style.css
+++ b/style.css
@@ -323,6 +323,10 @@ svg {
 
 input[name="toggle"] { display: none; }
 
+input[type="radio"][id^="ui-component-toggle__"] {
+  display: none;
+}
+
 .ui-component-toggle {
   background-color: var(--ui-color-background-tertiary);
   border-radius: var(--ui-radius-button);
@@ -358,7 +362,11 @@ input[name="toggle"] { display: none; }
 .page--plans #ui-component-toggle__monthly:checked ~
 div label[for=ui-component-toggle__monthly],
 .page--plans #ui-component-toggle__yearly:checked ~
-div label[for=ui-component-toggle__yearly] {
+div label[for=ui-component-toggle__yearly],
+.page--plans #ui-component-toggle__eur:checked ~
+div label[for=ui-component-toggle__eur],
+.page--plans #ui-component-toggle__usd:checked ~
+div label[for=ui-component-toggle__usd] {
   background-color: #4c97d9;
   color: #fff;
 }
@@ -815,29 +823,71 @@ div label[for=ui-component-toggle__yearly] {
 
 /* AMOUNT */
 
-.ui-component-card--pricing-amount-0::before { content: "$0"; }
+/* Default: Monthly EUR */
+.ui-component-card--pricing-amount-0::before { content: "€0"; }
 
+/* Yearly EUR */
 #ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-0::before { content: "€0"; }
+
+/* Monthly EUR */
+.ui-component-card--pricing-amount-1::before { content: "€30"; }
+
+/* Yearly EUR */
+#ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-1::before { content: "€27"; }
+
+/* Monthly EUR */
+.ui-component-card--pricing-amount-2::before { content: "€60"; }
+
+/* Yearly EUR */
+#ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-2::before { content: "€54"; }
+
+/* Monthly EUR */
+.ui-component-card--pricing-amount-3::before { content: "€90"; }
+
+/* Yearly EUR */
+#ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-3::before { content: "€81"; }
+
+/* Monthly EUR */
+.ui-component-card--pricing-amount-4::before { content: "€150"; }
+
+/* Yearly EUR */
+#ui-component-toggle__yearly:checked ~ div
+.ui-component-card--pricing-amount-4::before { content: "€135"; }
+
+/* Monthly USD */
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-0::before { content: "$0"; }
 
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-1::before { content: "$30"; }
 
-#ui-component-toggle__yearly:checked ~ div
-.ui-component-card--pricing-amount-1::before { content: "$27"; }
-
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-2::before { content: "$60"; }
 
-#ui-component-toggle__yearly:checked ~ div
-.ui-component-card--pricing-amount-2::before { content: "$54"; }
-
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-3::before { content: "$90"; }
 
-#ui-component-toggle__yearly:checked ~ div
-.ui-component-card--pricing-amount-3::before { content: "$81"; }
-
+#ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-4::before { content: "$150"; }
 
-#ui-component-toggle__yearly:checked ~ div
+/* Yearly USD */
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
+.ui-component-card--pricing-amount-0::before { content: "$0"; }
+
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
+.ui-component-card--pricing-amount-1::before { content: "$27"; }
+
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
+.ui-component-card--pricing-amount-2::before { content: "$54"; }
+
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
+.ui-component-card--pricing-amount-3::before { content: "$81"; }
+
+#ui-component-toggle__yearly:checked ~ #ui-component-toggle__usd:checked ~ div
 .ui-component-card--pricing-amount-4::before { content: "$135"; }
 
 /* LIST */


### PR DESCRIPTION
- Add currency toggle switch (EUR/USD) matching Monthly/Annual toggle design
- Change default pricing from USD to EUR (same numeric values: €30 = $30)
- Add CSS rules for USD pricing override when USD toggle is active
- Add CSS rules for combined states (yearly + USD pricing)
- Hide radio button inputs and style toggle labels for consistent UX
- Add descriptive text "Select your billing currency." below currency toggle