### PR TITLE
Mark GA4 reporting as active and Search Console as coming soon

### DIFF
--- a/_site/blog/why-webperformance-report-exists/index.html
+++ b/_site/blog/why-webperformance-report-exists/index.html
@@ -284,7 +284,9 @@
 <ul class="ui-post-checklist">
   <li>Added <strong>security reporting</strong> based on Mozilla HTTP Observatory.</li>
   <li>Added <strong>accessibility reporting</strong> based on WAVE.</li>
-  <li>Exploring future reports: Google Search Console, Shopify, Google Analytics, Website Carbon, and more.</li>
+  <li>Added <strong>analytics reporting</strong> based on Google Analytics 4.</li>
+  <li>Coming soon: <strong>search reporting</strong> based on Google Search Console.</li>
+  <li>Exploring future reports: Shopify, Website Carbon, and more.</li>
 </ul>
 <p>The idea is not to replace those tools. It is to amplify them. Measurement tools are excellent at observing, scanning, and generating data. WebPerformance Report adds the next layer:</p>
 <div class="ui-post-metric-cards">

--- a/_site/sitemap.xml
+++ b/_site/sitemap.xml
@@ -21,10 +21,6 @@
     <lastmod>2026-07-29</lastmod>
   </url>
   <url>
-    <loc>https://webperformancereport.com/blog/</loc>
-    <lastmod>2026-07-29</lastmod>
-  </url>
-  <url>
     <loc>https://webperformancereport.com/cookie-policy/</loc>
     <lastmod>2026-07-29</lastmod>
   </url>
@@ -41,19 +37,23 @@
     <lastmod>2026-07-29</lastmod>
   </url>
   <url>
+    <loc>https://webperformancereport.com/blog/</loc>
+    <lastmod>2026-07-30</lastmod>
+  </url>
+  <url>
     <loc>https://webperformancereport.com/report/ga4/</loc>
-    <lastmod>2026-07-29</lastmod>
+    <lastmod>2026-07-30</lastmod>
   </url>
   <url>
     <loc>https://webperformancereport.com/report/gsc/</loc>
-    <lastmod>2026-07-29</lastmod>
-  </url>
-  <url>
-    <loc>https://webperformancereport.com/report/wave/</loc>
-    <lastmod>2026-07-29</lastmod>
+    <lastmod>2026-07-30</lastmod>
   </url>
   <url>
     <loc>https://webperformancereport.com/report/httpo/</loc>
-    <lastmod>2026-07-29</lastmod>
+    <lastmod>2026-07-30</lastmod>
+  </url>
+  <url>
+    <loc>https://webperformancereport.com/report/wave/</loc>
+    <lastmod>2026-07-30</lastmod>
   </url>
 </urlset>

--- a/blog/why-webperformance-report-exists.md
+++ b/blog/why-webperformance-report-exists.md
@@ -134,7 +134,9 @@ At first, WebPerformance Report was focused on performance. But the more the pro
 <ul class="ui-post-checklist">
   <li>Added <strong>security reporting</strong> based on Mozilla HTTP Observatory.</li>
   <li>Added <strong>accessibility reporting</strong> based on WAVE.</li>
-  <li>Exploring future reports: Google Search Console, Shopify, Google Analytics, Website Carbon, and more.</li>
+  <li>Added <strong>analytics reporting</strong> based on Google Analytics 4.</li>
+  <li>Coming soon: <strong>search reporting</strong> based on Google Search Console.</li>
+  <li>Exploring future reports: Shopify, Website Carbon, and more.</li>
 </ul>
 
 The idea is not to replace those tools. It is to amplify them. Measurement tools are excellent at observing, scanning, and generating data. WebPerformance Report adds the next layer:


### PR DESCRIPTION
Google Analytics 4 and Google Search Console were both listed under "Exploring future reports". GA4 now has its own "Added" bullet alongside security and accessibility, and Search Console gets a "Coming soon" bullet, so both are removed from the exploring list to avoid stating GA4 is live and still being explored in consecutive lines.

Also picks up sitemap lastmod churn: pages without an explicit front-matter date fall back to file mtime, which git resets on checkout.